### PR TITLE
support cancelBulkOrder

### DIFF
--- a/botfw/gmocoin/api_ccxt.py
+++ b/botfw/gmocoin/api_ccxt.py
@@ -100,6 +100,7 @@ class gmocoin(ccxt.Exchange):
                         'order',
                         'changeOrder',
                         'cancelOrder',
+                        'cancelBulkOrder',
                         'closeOrder',
                         'closeBulkOrder',
                         'changeLosscutPrice',


### PR DESCRIPTION
https://api.coin.z.com/docs/#2020-11-04
2020-11-04に追加された一括キャンセルのエンドポイント対応です