### PR TITLE
ccxtによるfetch2の引数変更に対応

### DIFF
--- a/botfw/base/api.py
+++ b/botfw/base/api.py
@@ -37,7 +37,7 @@ class ApiBase:
 
     def fetch2(
             self, path, api='public', method='GET', params={},
-            headers=None, body=None):
+            headers=None, body=None, config={}, context={}):
         try:
             request = self.sign(
                 path, api, method, params, headers, body)


### PR DESCRIPTION
本家ccxtの三ヶ月ほど前のこちらのコミットより、関数fetch2()の引数が増えております。
https://github.com/ccxt/ccxt/commit/1ee638adc768512cd6e3ec2f548ae5103cb63612

これ以降のバージョンのccxtがインストールされていると、botfwの取引所インスタンス初期化の際に、以下のようなエラーが出ます。
> meetaco@appmbp bitflyer % python3 getbalance.py      
> Traceback (most recent call last):
>   File "/Users/meetaco/dev/botutil/bitflyer/getbalance.py", line 20, in <module>
>     bf_ex.init_account(ccxt_bf_config)
>   File "/opt/homebrew/lib/python3.9/site-packages/botfw/base/exchange.py", line 29, in init_account
>     self.api = self.Api(ccxt_config)
>   File "/opt/homebrew/lib/python3.9/site-packages/botfw/bitflyer/api.py", line 13, in __init__
>     self.load_markets()
>   File "/opt/homebrew/lib/python3.9/site-packages/ccxt/base/exchange.py", line 1423, in load_markets
>     markets = self.fetch_markets(params)
>   File "/opt/homebrew/lib/python3.9/site-packages/ccxt/bitflyer.py", line 99, in fetch_markets
>     jp_markets = self.publicGetGetmarkets(params)
>   File "/opt/homebrew/lib/python3.9/site-packages/ccxt/base/exchange.py", line 459, in inner
>     return entry(_self, **inner_kwargs)
>   File "/opt/homebrew/lib/python3.9/site-packages/ccxt/base/exchange.py", line 508, in request
>     return self.fetch2(path, api, method, params, headers, body, config, context)
> TypeError: fetch2() takes from 2 to 7 positional arguments but 9 were given

botfw側のfetch2()の引数も、ccxtのfetch2()に合わせることで対応しました。
問題なければマージしていただけると幸いです。