### PR TITLE
pip install git+https でインストールできるようにファイルを追加

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ long_description = file: README.md, LICENSE
 license = MIT
 classifiers =
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
 
 [options]
 zip_safe = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,19 @@
+[metadata]
+name = botfw 
+version = 0.5.0
+description = cryptocurrency bot framework 
+long_description = file: README.md, LICENSE
+license = MIT
+classifiers =
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.5
+
+[options]
+zip_safe = False
+packages = find:
+
+[options.packages.find]
+exclude =
+  test
+  samples
+

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,3 @@
 from setuptools import setup
 
-setup(install_requires=['ccxt'])
+setup(install_requires=['ccxt', 'websockets', 'sortedcontainers'])

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+
+setup(install_requires=['ccxt'])


### PR DESCRIPTION
pipでインストールできないのが不便だったので修正してみました。
pip install git+https://github.com/penta2019/btc_bot_framework
でインストールできるようになります。

お試しは自分のレポジトリでやってもらえればと思います。
pip install git+https://github.com/bols-blue/btc_bot_framework
